### PR TITLE
Fix RN naming conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
         "preset": "react-native"
     },
     "dependencies": {
-        "lodash.merge": "^4.6.0",
-        "prop-types": "^15.6.0",
-        "react": "=16.0.0",
-        "react-native": "=0.50.4",
-        "react-native-animatable": "^1.2.4"
+        "lodash.merge": "^4.6.0"
+    },
+    "peerDependencies": {
+        "react": ">=15.4.0 || ^16.0.0-alpha",
+        "react-native": ">=0.40",
+        "prop-types": "^15.5.10"
     },
     "devDependencies": {
         "babel-eslint": "^8.0.1",
@@ -43,6 +44,10 @@
         "eslint-plugin-react": "^7.4.0",
         "eslint-plugin-react-native": "^3.1.0",
         "jest": "21.2.1",
-        "react-test-renderer": "16.0.0-beta.5"
+        "react-test-renderer": "16.0.0-beta.5",
+        "prop-types": "^15.6.0",
+        "react": "=16.0.0",
+        "react-native": "=0.50.4",
+        "react-native-animatable": "^1.2.4"
     }
 }


### PR DESCRIPTION
This dependencies fix solves issues of an app using different versions/forks of RN than React Native Search Header

[react-native-search-header/issues/13](https://github.com/tuantle/react-native-search-header/issues/13)
[react-native-search-header/issues/7](https://github.com/tuantle/react-native-search-header/issues/7)