### PR TITLE
Version patch for RN naming conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-search-header",
-    "version": "0.2.2",
+    "version": "0.2.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-search-header",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "registry": "github",
     "description": "A react native search header component based on material design patterns.",
     "authors": [


### PR DESCRIPTION
Quick follow-up commit for `fix/rn-naming-collison` which was merged into master. Bumping version to allow changes to be picked up by NPM